### PR TITLE
Feature challenge fix

### DIFF
--- a/src/main/java/projectbuildup/saver/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/projectbuildup/saver/domain/challenge/controller/ChallengeController.java
@@ -70,9 +70,15 @@ public class ChallengeController {
         return new ResponseEntity<>(getChallengeResDto, HttpStatus.OK);
     }
 
-    @DeleteMapping("")
+    @PostMapping("/left")
     public ResponseEntity<HttpStatus> leftChallenge(@RequestBody LeftChallengeReqDto leftChallengeReqDto) {
         challengeService.leftChallenge(leftChallengeReqDto.getLoginId(), leftChallengeReqDto.getChallengeId());
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{challengeId}")
+    public ResponseEntity<HttpStatus> deleteChallenge(@PathVariable Long challengeId) {
+        challengeService.deleteChallenge(challengeId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/src/main/java/projectbuildup/saver/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/projectbuildup/saver/domain/challenge/controller/ChallengeController.java
@@ -9,6 +9,7 @@ import projectbuildup.saver.domain.challenge.service.interfaces.ChallengeService
 import projectbuildup.saver.domain.dto.req.CreateChallengeReqDto;
 import projectbuildup.saver.domain.dto.req.JoinChallengeReqDto;
 import projectbuildup.saver.domain.dto.req.LeftChallengeReqDto;
+import projectbuildup.saver.domain.dto.res.GetChallengeListResDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeParticipantsResDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeResDto;
 
@@ -43,8 +44,8 @@ public class ChallengeController {
     }
 
     @GetMapping("/available")
-    public ResponseEntity<List<GetChallengeResDto>> getAvailableChallenges(@RequestParam Long sortType, @RequestParam Boolean ascending, @RequestParam String loginId) {
-        List<GetChallengeResDto> challenges = challengeService.getAvailableChallenges(sortType, ascending, loginId);
+    public ResponseEntity<GetChallengeListResDto> getAvailableChallenges(@RequestParam Long sortType, @RequestParam Boolean ascending, @RequestParam String loginId) {
+        GetChallengeListResDto challenges = challengeService.getAvailableChallenges(sortType, ascending, loginId);
         if (challenges != null) {
             return new ResponseEntity<>(challenges, HttpStatus.OK);
         } else {
@@ -53,8 +54,8 @@ public class ChallengeController {
     }
 
     @GetMapping("/my")
-    public ResponseEntity<List<GetChallengeResDto>> getMyChallenges(@RequestParam String loginId) {
-        List<GetChallengeResDto> challenges = challengeService.getMyChallenges(loginId);
+    public ResponseEntity<GetChallengeListResDto> getMyChallenges(@RequestParam String loginId) {
+        GetChallengeListResDto challenges = challengeService.getMyChallenges(loginId);
         if (challenges != null) {
             return new ResponseEntity<>(challenges, HttpStatus.OK);
         } else {

--- a/src/main/java/projectbuildup/saver/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/projectbuildup/saver/domain/challenge/controller/ChallengeController.java
@@ -9,6 +9,7 @@ import projectbuildup.saver.domain.challenge.service.interfaces.ChallengeService
 import projectbuildup.saver.domain.dto.req.CreateChallengeReqDto;
 import projectbuildup.saver.domain.dto.req.JoinChallengeReqDto;
 import projectbuildup.saver.domain.dto.req.LeftChallengeReqDto;
+import projectbuildup.saver.domain.dto.req.UpdateChallengeReqDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeListResDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeParticipantsResDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeResDto;
@@ -79,6 +80,12 @@ public class ChallengeController {
     @DeleteMapping("/{challengeId}")
     public ResponseEntity<HttpStatus> deleteChallenge(@PathVariable Long challengeId) {
         challengeService.deleteChallenge(challengeId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PutMapping("/{challengeId}")
+    public ResponseEntity<HttpStatus> updateChallenge(@PathVariable Long challengeId, @RequestBody UpdateChallengeReqDto updated) {
+        challengeService.updateChallenge(challengeId, updated);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/src/main/java/projectbuildup/saver/domain/challenge/entity/ChallengeEntity.java
+++ b/src/main/java/projectbuildup/saver/domain/challenge/entity/ChallengeEntity.java
@@ -2,6 +2,7 @@ package projectbuildup.saver.domain.challenge.entity;
 
 import lombok.*;
 import projectbuildup.saver.domain.challengeLog.entity.ChallengeLogEntity;
+import projectbuildup.saver.domain.dto.req.UpdateChallengeReqDto;
 import projectbuildup.saver.domain.ranking.entity.RankingEntity;
 import projectbuildup.saver.domain.saving.entity.SavingEntity;
 import projectbuildup.saver.global.common.BaseTimeEntity;
@@ -59,5 +60,14 @@ public class ChallengeEntity extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "challenge", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<ChallengeLogEntity> challengeLogEntityList;
+
+    public void updateChallenge(UpdateChallengeReqDto updated) {
+        this.startDate = updated.getStartDate();
+        this.endDate = updated.getEndDate();
+        this.mainTitle = updated.getMainTitle();
+        this.subTitle = updated.getSubTitle();
+        this.content = updated.getContent();
+        this.savingAmount = updated.getSavingAmount();
+    }
 
 }

--- a/src/main/java/projectbuildup/saver/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/projectbuildup/saver/domain/challenge/service/ChallengeServiceImpl.java
@@ -11,6 +11,7 @@ import projectbuildup.saver.domain.challenge.service.interfaces.ChallengeService
 import projectbuildup.saver.domain.challengeLog.entity.ChallengeLogEntity;
 import projectbuildup.saver.domain.challengeLog.repository.ChallengeLogRepository;
 import projectbuildup.saver.domain.dto.req.CreateChallengeReqDto;
+import projectbuildup.saver.domain.dto.req.UpdateChallengeReqDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeListResDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeResDto;
 import projectbuildup.saver.domain.dto.res.ParticipantResDto;
@@ -243,5 +244,13 @@ public class ChallengeServiceImpl implements ChallengeService {
             throw new CChallengeNotFoundException();
         }
     }
+
+    @Override
+    public void updateChallenge(Long challengeId, UpdateChallengeReqDto updated) {
+        ChallengeEntity challenge = challengeRepository.findById(challengeId).orElseThrow(CChallengeNotFoundException::new);
+        challenge.updateChallenge(updated);
+        challengeRepository.save(challenge);
+    }
+
 
 }

--- a/src/main/java/projectbuildup/saver/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/projectbuildup/saver/domain/challenge/service/ChallengeServiceImpl.java
@@ -11,6 +11,7 @@ import projectbuildup.saver.domain.challenge.service.interfaces.ChallengeService
 import projectbuildup.saver.domain.challengeLog.entity.ChallengeLogEntity;
 import projectbuildup.saver.domain.challengeLog.repository.ChallengeLogRepository;
 import projectbuildup.saver.domain.dto.req.CreateChallengeReqDto;
+import projectbuildup.saver.domain.dto.res.GetChallengeListResDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeResDto;
 import projectbuildup.saver.domain.dto.res.ParticipantResDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeParticipantsResDto;
@@ -96,7 +97,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     @Override
-    public List<GetChallengeResDto> getAvailableChallenges(Long sortType, Boolean ascending, String loginId) {
+    public GetChallengeListResDto getAvailableChallenges(Long sortType, Boolean ascending, String loginId) {
 
         // 모든 챌린지 가져옴
         List<ChallengeEntity> challenges = challengeRepository.findAll();
@@ -135,22 +136,27 @@ public class ChallengeServiceImpl implements ChallengeService {
             return null;
         }
 
+        List<GetChallengeResDto> challengeList = (List<GetChallengeResDto>) selectedChallenges
+                .stream()
+                .map((challenge) -> {
+                    return new GetChallengeResDto(
+                            challenge.getId(),
+                            challenge.getStartDate(),
+                            challenge.getEndDate(),
+                            challenge.getMainTitle(),
+                            challenge.getSubTitle(),
+                            challenge.getContent(),
+                            challenge.getSavingAmount(),
+                            (long) challenge.getChallengeLogEntityList().size()
+                    );
+                })
+                .toList();
+
         // Dto로 변환 후 리턴.
-        return (List<GetChallengeResDto>) selectedChallenges
-                                                            .stream()
-                                                            .map((challenge) -> {
-                                                                return new GetChallengeResDto(
-                                                                        challenge.getId(),
-                                                                        challenge.getStartDate(),
-                                                                        challenge.getEndDate(),
-                                                                        challenge.getMainTitle(),
-                                                                        challenge.getSubTitle(),
-                                                                        challenge.getContent(),
-                                                                        challenge.getSavingAmount(),
-                                                                        (long) challenge.getChallengeLogEntityList().size()
-                                                                );
-                                                            })
-                                                            .toList();
+        return GetChallengeListResDto.builder()
+                .challengCnt((long) challengeList.size())
+                .challengeList(challengeList)
+                .build();
     }
 
     @Override
@@ -169,9 +175,10 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     @Override
-    public List<GetChallengeResDto> getMyChallenges(String loginId) {
+    public GetChallengeListResDto getMyChallenges(String loginId) {
         // 전부 찾아서 loginId가 같은 user가 있는 챌린지만 추려낸 후 리턴.
         List<ChallengeEntity> challenges = challengeRepository.findAll();
+
         List<ChallengeEntity> userChallenges = challenges
                 .stream()
                 .filter((challenge) -> {
@@ -185,7 +192,8 @@ public class ChallengeServiceImpl implements ChallengeService {
                     return false;
                 })
                 .toList();
-        return (List<GetChallengeResDto>) userChallenges
+
+        List<GetChallengeResDto> challengeList = (List<GetChallengeResDto>) userChallenges
                 .stream()
                 .map((challenge) -> {
                     return new GetChallengeResDto(
@@ -200,6 +208,12 @@ public class ChallengeServiceImpl implements ChallengeService {
                     );
                 })
                 .toList();
+
+        // Dto로 변환 후 리턴.
+        return GetChallengeListResDto.builder()
+                .challengCnt((long) challengeList.size())
+                .challengeList(challengeList)
+                .build();
     }
 
     @Override

--- a/src/main/java/projectbuildup/saver/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/projectbuildup/saver/domain/challenge/service/ChallengeServiceImpl.java
@@ -235,4 +235,13 @@ public class ChallengeServiceImpl implements ChallengeService {
         challengeLogRepository.deleteByChallengeAndUser(challenge, user);
     }
 
+    @Override
+    public void deleteChallenge(Long challengeId) {
+        try {
+            challengeRepository.deleteById(challengeId);
+        } catch (IllegalArgumentException e) {
+            throw new CChallengeNotFoundException();
+        }
+    }
+
 }

--- a/src/main/java/projectbuildup/saver/domain/challenge/service/interfaces/ChallengeService.java
+++ b/src/main/java/projectbuildup/saver/domain/challenge/service/interfaces/ChallengeService.java
@@ -25,14 +25,14 @@ public interface ChallengeService {
      * 현재 참여 가능한 챌린지를 모두 보여줌, 자신이 참여한것 제외, 특정 타입으로 정렬해야함
      * @param sortType {Long} 1 -> 참여자 수 2 -> 송금 금액 3 -> 종료일자
      * @param ascending {Boolean} 오름차순인지 내림차순인지
-     * @return
+     * @return GetChallengeListResDto 챌린지 리스트와 갯수
      */
     GetChallengeListResDto getAvailableChallenges(Long sortType, Boolean ascending, String loginId);
 
     /**
      * 단일 챌린지 리턴.
      * @param challengeId {Long} - 챌린지 아이디
-     * @return
+     * @return GetChallengeListResDto 챌린지 리스트와 갯수
      */
     GetChallengeResDto getChallenge(Long challengeId);
 
@@ -56,5 +56,11 @@ public interface ChallengeService {
      * @param challengeId {Long} 챌린지 아이디
      */
     void leftChallenge(String loginId, Long challengeId);
+
+    /**
+     * 챌린지 삭제
+     * @param challengeId {Long} 챌린지 아이디
+     */
+    void deleteChallenge(Long challengeId);
 
 }

--- a/src/main/java/projectbuildup/saver/domain/challenge/service/interfaces/ChallengeService.java
+++ b/src/main/java/projectbuildup/saver/domain/challenge/service/interfaces/ChallengeService.java
@@ -1,6 +1,8 @@
 package projectbuildup.saver.domain.challenge.service.interfaces;
 
+import org.hibernate.sql.Update;
 import projectbuildup.saver.domain.dto.req.CreateChallengeReqDto;
+import projectbuildup.saver.domain.dto.req.UpdateChallengeReqDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeListResDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeParticipantsResDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeResDto;
@@ -62,5 +64,12 @@ public interface ChallengeService {
      * @param challengeId {Long} 챌린지 아이디
      */
     void deleteChallenge(Long challengeId);
+
+    /**
+     * 챌린지 업데이트
+     * @param challengeId
+     */
+    void updateChallenge(Long challengeId, UpdateChallengeReqDto updated);
+
 
 }

--- a/src/main/java/projectbuildup/saver/domain/challenge/service/interfaces/ChallengeService.java
+++ b/src/main/java/projectbuildup/saver/domain/challenge/service/interfaces/ChallengeService.java
@@ -1,6 +1,7 @@
 package projectbuildup.saver.domain.challenge.service.interfaces;
 
 import projectbuildup.saver.domain.dto.req.CreateChallengeReqDto;
+import projectbuildup.saver.domain.dto.res.GetChallengeListResDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeParticipantsResDto;
 import projectbuildup.saver.domain.dto.res.GetChallengeResDto;
 
@@ -26,7 +27,7 @@ public interface ChallengeService {
      * @param ascending {Boolean} 오름차순인지 내림차순인지
      * @return
      */
-    List<GetChallengeResDto> getAvailableChallenges(Long sortType, Boolean ascending, String loginId);
+    GetChallengeListResDto getAvailableChallenges(Long sortType, Boolean ascending, String loginId);
 
     /**
      * 단일 챌린지 리턴.
@@ -40,7 +41,7 @@ public interface ChallengeService {
      * @param loginId {String} 유저 로그인 아아디
      * @return 유저가 참여중인 챌린지들의 리스트
      */
-    List<GetChallengeResDto> getMyChallenges(String loginId);
+    GetChallengeListResDto getMyChallenges(String loginId);
 
     /**
      * 챌린지 참여

--- a/src/main/java/projectbuildup/saver/domain/dto/req/UpdateChallengeReqDto.java
+++ b/src/main/java/projectbuildup/saver/domain/dto/req/UpdateChallengeReqDto.java
@@ -1,0 +1,20 @@
+package projectbuildup.saver.domain.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateChallengeReqDto {
+
+    private String startDate;
+    private String endDate;
+    private String mainTitle;
+    private String subTitle;
+    private String content;
+    private Long savingAmount;
+}

--- a/src/main/java/projectbuildup/saver/domain/dto/res/GetChallengeListResDto.java
+++ b/src/main/java/projectbuildup/saver/domain/dto/res/GetChallengeListResDto.java
@@ -1,0 +1,15 @@
+package projectbuildup.saver.domain.dto.res;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GetChallengeListResDto {
+    private Long challengCnt;
+    private List<GetChallengeResDto> challengeList;
+}


### PR DESCRIPTION
- 챌린지를 여러개 리턴할때 기존엔 List에 개별 챌린지 Dto를 쐈지만, 이를 다른 Dto로 감싸 챌린지의 갯수와 리스트를 담도록 수정하였음.
- 챌린지 탈퇴는 Delete와 맞지 않는다 생각해 /challenge/left 로 URI 바꾸고, 기존의 DELETE는  /challenge/{challengeId}로 수정하여 챌린지 삭제 코드로 변경하였음
- 챌린지 업데이트 코드 작성.